### PR TITLE
Replaced subreddit links with absolute links

### DIFF
--- a/content.js
+++ b/content.js
@@ -317,7 +317,7 @@ function setRedditComments(url)
         
       if (comments.length>0)
       {
-		comments.html(comments.html().replace(/href\="\/r\//g, 'href="https://www.reddit.com/r/'));
+        comments.html(comments.html().replace(/href\="\/r\//g, 'href="https://www.reddit.com/r/'));
 		  
         container.append(comments);
       }

--- a/content.js
+++ b/content.js
@@ -317,6 +317,8 @@ function setRedditComments(url)
         
       if (comments.length>0)
       {
+		comments.html(comments.html().replace(/href\="\/r\//g, 'href="https://www.reddit.com/r/'));
+		  
         container.append(comments);
       }
       else

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Luke's reddit on Youtube™",
   "description": "Adds reddit comments to youtube videos",
-  "version": "0.28",
+  "version": "0.29",
   "permissions": [
     "http://*.youtube.com/*", "https://*.youtube.com/*", "http://www.reddit.com/*", "https://www.reddit.com/*"
   ],


### PR DESCRIPTION
Links to subreddits in comments used to point to "https://www.youtube.com/r/...".

As someone who uses the extension quite often this annoyed me a bit. So I decided to change it so it replaces the relative links in the reddit comments with absolute ones.